### PR TITLE
add async option to standalone urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,21 @@ You can also use dynamic urls:
 ```javascript
 // vue.config.js
 
+// Async function to get dynamic url
+async function buildSitemapUrls() {
+   const boardList = await fetch('your_api').then(function (response) {
+      return response.json();
+   }).then(function (responseJson) {
+      // It depends on your json format.
+      return responseJson.body.items.map(each => "/your_path/" + each.board.boardWriteId);
+   });
+   return [ '/', '/about'].concat(boardList);
+}
+
 module.exports = {
 	pluginOptions: {
 		sitemap: {
-                        urls: (async () => { return await buildSitemapUrls(); })()
+                        urls: buildSitemapUrls()
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ module.exports = {
 }
 ```
 
+#### Usage as a standalone plugin with dynamic urls
+You can also use dynamic urls:
+```javascript
+// vue.config.js
+
+module.exports = {
+	pluginOptions: {
+		sitemap: {
+                        urls: (async () => { return await buildSitemapUrls(); })()
+		}
+	}
+}
+```
+
 If both routes and  URLs are provided, they will be merged  together in a single
 sitemap. In the case of duplicated locations, handwritten URLs will prevail over
 their matching routes.

--- a/index.js
+++ b/index.js
@@ -77,6 +77,10 @@ module.exports = async function(api, vueCliOptions) {
 }
 
 async function writeSitemap(options, outputDir) {
+
+	// Resolve if urls is Promise
+	options.urls = await options.urls;
+
 	// Validate options and set default values
 	validateOptions(options, true);
 


### PR DESCRIPTION
Added code so that dynamic url can be delivered asynchronously even when using plugin in standalone form.

If you create a url asynchronously in vue.config.js and assign it to sitemap.urls, the code is as follows.
```
vue.config.js

pluginOptions: {
    sitemap: {
      pretty: true,
      baseURL: 'https://online.gamecoach.pro',
      defaults: {
        lastmod: new Date().toISOString(),
        changefreq: 'weekly',
        priority: 1.0
      },
      urls: (async () => { return await buildSitemapUrls(); })()
    }
  }
```

At this time, the array wrapped in the Promise object is delivered to the plugin, and the Promise is resolved by awaiting the plugin's options.urls value.