### PR TITLE
null pointer during dynamic route without children #30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vue-cli-plugin-sitemap",
       "version": "2.3.0",
       "license": "ISC",
       "dependencies": {
@@ -767,7 +768,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/src/sitemap.js
+++ b/src/sitemap.js
@@ -117,8 +117,8 @@ async function generateURLsFromRoutes(routes, parentPath = '', parentMeta = {}) 
 		/**
 		 * Static route
 		 */
-		if ('loc' in meta)  return ('children' in route) ? await generateURLsFromRoutes(route.children, meta.loc, meta) : meta;
-		if (!params.length) return ('children' in route) ? await generateURLsFromRoutes(route.children, path,     meta) : { loc: path, ...meta };
+		if ('loc' in meta)  return ('children' in route && route.children != null) ? await generateURLsFromRoutes(route.children, meta.loc, meta) : meta;
+		if (!params.length) return ('children' in route && route.children != null) ? await generateURLsFromRoutes(route.children, path,     meta) : { loc: path, ...meta };
 
 		/**
 		 * Dynamic route
@@ -146,7 +146,7 @@ async function generateURLsFromRoutes(routes, parentPath = '', parentMeta = {}) 
 				return result.replace(param.str, slug[param.name]);
 			}, path);
 
-			return ('children' in route) ? await generateURLsFromRoutes(route.children, loc, meta) : { loc, ...slug };
+			return ('children' in route && route.children != null) ? await generateURLsFromRoutes(route.children, loc, meta) : { loc, ...slug };
 		})));
 	}))
 

--- a/test/sitemap.test.js
+++ b/test/sitemap.test.js
@@ -669,6 +669,16 @@ describe("single sitemap", () => {
 			));
 		});
 
+		it("does not throw for dynamic route with undefined children when given slugs", async () => {
+			return expect(Promise.resolve(generate({
+				baseURL: 'https://example.com',
+				routes:  [
+					{ path: '/' }, 
+					{ path: '/something/:alt', children: undefined, meta: { sitemap: { slugs: [{alt: "someting", priority: 0.8}] }}}
+				],
+			}))).to.eventually.be.any;
+		});
+
 		it("throws an error when dynamic routes are not given slugs", async () => {
 			return expect(Promise.resolve(generate({
 				baseURL: 'https://example.com',

--- a/test/sitemap.test.js
+++ b/test/sitemap.test.js
@@ -670,13 +670,15 @@ describe("single sitemap", () => {
 		});
 
 		it("does not throw for dynamic route with undefined children when given slugs", async () => {
-			return expect(Promise.resolve(generate({
+			return expect(await generate({
 				baseURL: 'https://example.com',
 				routes:  [
 					{ path: '/' }, 
-					{ path: '/something/:alt', children: undefined, meta: { sitemap: { slugs: [{alt: "someting", priority: 0.8}] }}}
+					{ path: '/something/:alt', children: undefined, meta: { sitemap: { slugs: [{alt: "something", priority: 0.8}] }}}
 				],
-			}))).to.eventually.be.any;
+			})).to.deep.equal(wrapSitemap(
+				'<url><loc>https://example.com</loc></url><url><loc>https://example.com/something/something</loc><priority>0.8</priority></url>'
+			));
 		});
 
 		it("throws an error when dynamic routes are not given slugs", async () => {


### PR DESCRIPTION
added unit test and logic fix for undefined children during sitemap generation.

there is probably a situation in the generation system which might need to be addressed to stop generating null/undefined child references when they are not provided and `/route/:dynamic` paths are present.